### PR TITLE
Rest docs 문서 수정

### DIFF
--- a/src/main/java/com/example/villagerservice/member/api/AuthApiController.java
+++ b/src/main/java/com/example/villagerservice/member/api/AuthApiController.java
@@ -34,7 +34,7 @@ public class AuthApiController {
         memberService.createMember(createMember);
     }
 
-    @GetMapping("/valid/nickname")
+    @PostMapping("/valid/nickname")
     public void validNickname(@Valid @RequestBody ValidMemberNickname.Request request) {
         memberService.validNickname(request);
     }

--- a/src/test/java/com/example/document/BaseDocumentation.java
+++ b/src/test/java/com/example/document/BaseDocumentation.java
@@ -14,15 +14,14 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.Schema.schema;
 import static io.restassured.RestAssured.given;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
 
@@ -81,7 +80,7 @@ public abstract class BaseDocumentation {
                 ));
     }
 
-    protected RequestSpecification givenAuth(String body, RestDocumentation restDocumentation) {
+    protected RequestSpecification givenAuthRefreshToken(String body, RestDocumentation restDocumentation) {
         return given(this.spec)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .header("Content-type", "application/json")
@@ -105,6 +104,35 @@ public abstract class BaseDocumentation {
                                         .requestHeaders(Arrays.asList(
                                                 new HeaderDescriptorWithType(AUTHORIZATION).description("JWT Access-Token"),
                                                 new HeaderDescriptorWithType("refresh-token").description("JWT Refresh-Token")
+                                        ))
+                                        .build()
+                        )
+                ));
+    }
+
+    protected RequestSpecification givenAuth(String body, RestDocumentation restDocumentation) {
+        return given(this.spec)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .header("Content-type", "application/json")
+                .body(body)
+                .log().all()
+                .filter(document(
+                        restDocumentation.getIdentifier(),
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(restDocumentation.getTag())
+                                        .summary(restDocumentation.getSummary())
+                                        .description(restDocumentation.getDescription())
+                                        .requestSchema(schema(restDocumentation.getRequestSchema()))
+                                        .responseSchema(schema(restDocumentation.getResponseSchema()))
+                                        .requestFields(restDocumentation.getRequestFields())
+                                        .pathParameters(restDocumentation.getPathParameters())
+                                        .requestParameters(restDocumentation.getRequestParameters())
+                                        .responseFields(restDocumentation.getResponseFields())
+                                        .requestHeaders(List.of(
+                                                new HeaderDescriptorWithType(AUTHORIZATION).description("JWT Access-Token")
                                         ))
                                         .build()
                         )

--- a/src/test/java/com/example/villagerservice/member/api/AuthApiControllerIntegratedTest.java
+++ b/src/test/java/com/example/villagerservice/member/api/AuthApiControllerIntegratedTest.java
@@ -119,7 +119,7 @@ class AuthApiControllerIntegratedTest extends BaseDocumentation {
         JwtTokenResponse jwtTokenResponse = getJwtTokenResponse();
 
         // when & then
-        Response refreshTokenResponse = givenAuth("",
+        Response refreshTokenResponse = givenAuthRefreshToken("",
                 template.responseRestDocumentation(
                         "토큰 재요청",
                         getJwtTokenResponseFields(),
@@ -201,7 +201,7 @@ class AuthApiControllerIntegratedTest extends BaseDocumentation {
                         getValidNicknameRequestFields(),
                         ValidMemberNickname.Request.class.getName()))
                 .when()
-                .get("/api/v1/auth/valid/nickname")
+                .post("/api/v1/auth/valid/nickname")
                 .then()
                 .statusCode(HttpStatus.OK.value());
     }

--- a/src/test/java/com/example/villagerservice/member/api/AuthApiControllerTest.java
+++ b/src/test/java/com/example/villagerservice/member/api/AuthApiControllerTest.java
@@ -316,7 +316,7 @@ class AuthApiControllerTest {
         String body = objectMapper.writeValueAsString(request);
 
         // when & then
-        mockMvc.perform(get("/api/v1/auth/valid/nickname")
+        mockMvc.perform(post("/api/v1/auth/valid/nickname")
                         .contentType(APPLICATION_JSON)
                         .content(body)
                 )
@@ -342,7 +342,7 @@ class AuthApiControllerTest {
                 .validNickname(any());
 
         // when & then
-        mockMvc.perform(get("/api/v1/auth/valid/nickname")
+        mockMvc.perform(post("/api/v1/auth/valid/nickname")
                         .contentType(APPLICATION_JSON)
                         .content(body)
                 )

--- a/src/test/java/com/example/villagerservice/member/api/MemberApiControllerIntegratedTest.java
+++ b/src/test/java/com/example/villagerservice/member/api/MemberApiControllerIntegratedTest.java
@@ -68,7 +68,6 @@ class MemberApiControllerIntegratedTest extends BaseDocumentation {
                         UpdateMemberInfo.Request.class.getName()))
                 .when()
                 .header(AUTHORIZATION, "Bearer " + jwtTokenResponse.getAccessToken())
-                .header("refresh-token", jwtTokenResponse.getRefreshToken())
                 .patch("/api/v1/members/info")
                 .then()
                 .statusCode(HttpStatus.OK.value());
@@ -99,7 +98,6 @@ class MemberApiControllerIntegratedTest extends BaseDocumentation {
                         UpdateMemberPassword.Request.class.getName()))
                 .when()
                 .header(AUTHORIZATION, "Bearer " + jwtTokenResponse.getAccessToken())
-                .header("refresh-token", jwtTokenResponse.getRefreshToken())
                 .patch("/api/v1/members/password")
                 .then()
                 .statusCode(HttpStatus.OK.value());
@@ -122,7 +120,6 @@ class MemberApiControllerIntegratedTest extends BaseDocumentation {
                         "회원 탈퇴"))
                 .when()
                 .header(AUTHORIZATION, "Bearer " + jwtTokenResponse.getAccessToken())
-                .header("refresh-token", jwtTokenResponse.getRefreshToken())
                 .delete("/api/v1/members")
                 .then()
                 .statusCode(HttpStatus.OK.value());
@@ -152,7 +149,6 @@ class MemberApiControllerIntegratedTest extends BaseDocumentation {
                         CreateMemberAttentionTag.Request.class.getName()))
                 .when()
                 .header(AUTHORIZATION, "Bearer " + jwtTokenResponse.getAccessToken())
-                .header("refresh-token", jwtTokenResponse.getRefreshToken())
                 .post("/api/v1/members/tags")
                 .then()
                 .statusCode(HttpStatus.OK.value());


### PR DESCRIPTION
### PR 내용
- 토큰 재발행 빼고 나머지 요청에 대해서 request header에 refresh-token 부분 제거
- 닉네임 중복 검사 GET Method에서 POST Method로 변경